### PR TITLE
Refactor registration to use temp password and confirmation

### DIFF
--- a/src/main/java/com/csselect/API/APIFacadeOrganiser.java
+++ b/src/main/java/com/csselect/API/APIFacadeOrganiser.java
@@ -19,15 +19,14 @@ public class APIFacadeOrganiser extends APIFacadeUser {
 
     /** registers a new organiser. This will create a new Organiser in the database
      *
-     * @param args String array of arguments for registration
-     *             0: email
-     *             1: masterpassword
+     * @param email organisers email
+     * @param masterPassword password needed for organiser registration
      * @return true if registration successfull, false otherwise
      * @throws IllegalArgumentException if email is in use or the masterpassword is incorrect
      */
-    public boolean register(String[] args) throws IllegalArgumentException {
+    public boolean register(String email, String masterPassword) throws IllegalArgumentException {
         OrganiserManagement om = new OrganiserManagement();
-        organiser = om.register(args);
+        organiser = om.register(email, masterPassword);
         return organiser != null;
     }
 

--- a/src/main/java/com/csselect/API/APIFacadeOrganiser.java
+++ b/src/main/java/com/csselect/API/APIFacadeOrganiser.java
@@ -21,8 +21,7 @@ public class APIFacadeOrganiser extends APIFacadeUser {
      *
      * @param args String array of arguments for registration
      *             0: email
-     *             1: password
-     *             2: masterpassword
+     *             1: masterpassword
      * @return true if registration successfull, false otherwise
      * @throws IllegalArgumentException if email is in use or the masterpassword is incorrect
      */

--- a/src/main/java/com/csselect/API/APIFacadePlayer.java
+++ b/src/main/java/com/csselect/API/APIFacadePlayer.java
@@ -27,15 +27,13 @@ public class APIFacadePlayer extends APIFacadeUser {
     /**
      * registers a new player
      *
-     * @param args array with arguments for this method
-     *             0: email
-     *             1: username
+     * @param email players email address
+     * @param username players username
      * @return true if registration successful, false otherwise
      */
-    @Override
-    public boolean register(String[] args) {
+    public boolean register(String email, String username) {
         PlayerManagement pm = new PlayerManagement();
-        player = pm.register(args);
+        player = pm.register(email, username);
         return player != null;
     }
 

--- a/src/main/java/com/csselect/API/APIFacadePlayer.java
+++ b/src/main/java/com/csselect/API/APIFacadePlayer.java
@@ -29,8 +29,7 @@ public class APIFacadePlayer extends APIFacadeUser {
      *
      * @param args array with arguments for this method
      *             0: email
-     *             1: password
-     *             2: username
+     *             1: username
      * @return true if registration successful, false otherwise
      */
     @Override

--- a/src/main/java/com/csselect/API/APIFacadeUser.java
+++ b/src/main/java/com/csselect/API/APIFacadeUser.java
@@ -7,15 +7,6 @@ package com.csselect.API;
 
 public abstract class APIFacadeUser {
 
-    /** Registers a new user.
-     * This creates a new user in the database.
-     * Password and email are later required to log into the system with {@link APIFacadeUser#login(String, String)}
-     * @param args String array of arguments for registration
-     * @return true if registration successfull, false otherwise
-     */
-
-    public abstract boolean register(String[] args);
-
 
     /** logs in a user for this api. This is the first method that has to be called before any other methods start
      *  making sense.

--- a/src/main/java/com/csselect/API/httpAPI/Login.java
+++ b/src/main/java/com/csselect/API/httpAPI/Login.java
@@ -66,7 +66,7 @@ public class Login extends Servlet {
         if (isSet("organiser", req)) {
             createOrganiser();
             try {
-                success = getOrganiserFacade().register(new String[]{email, second});
+                success = getOrganiserFacade().register(email, second);
             } catch (IllegalArgumentException e) {
                 if (e.getMessage().equals(OrganiserManagement.EMAIL_IN_USE)) {
                     resp.sendError(409, e.getMessage());
@@ -78,7 +78,7 @@ public class Login extends Servlet {
             }
         } else {
             createPlayer();
-            success = getPlayerFacade().register(new String[]{email, second});
+            success = getPlayerFacade().register(email, second);
         }
         if (success) {
             resp.sendError(HttpServletResponse.SC_OK);

--- a/src/main/java/com/csselect/API/httpAPI/Login.java
+++ b/src/main/java/com/csselect/API/httpAPI/Login.java
@@ -61,12 +61,12 @@ public class Login extends Servlet {
 
     private void register(HttpServletRequest req, HttpServletResponse resp) throws HttpError, IOException {
         String email = getParameter("email", req);
-        String third = getParameter("thirdParam", req);
+        String second = getParameter("secondParam", req);
         boolean success = false;
         if (isSet("organiser", req)) {
             createOrganiser();
             try {
-                success = getOrganiserFacade().register(new String[]{email, third});
+                success = getOrganiserFacade().register(new String[]{email, second});
             } catch (IllegalArgumentException e) {
                 if (e.getMessage().equals(OrganiserManagement.EMAIL_IN_USE)) {
                     resp.sendError(409, e.getMessage());
@@ -78,7 +78,7 @@ public class Login extends Servlet {
             }
         } else {
             createPlayer();
-            success = getPlayerFacade().register(new String[]{email, third});
+            success = getPlayerFacade().register(new String[]{email, second});
         }
         if (success) {
             resp.sendError(HttpServletResponse.SC_OK);

--- a/src/main/java/com/csselect/API/httpAPI/Login.java
+++ b/src/main/java/com/csselect/API/httpAPI/Login.java
@@ -61,14 +61,12 @@ public class Login extends Servlet {
 
     private void register(HttpServletRequest req, HttpServletResponse resp) throws HttpError, IOException {
         String email = getParameter("email", req);
-        String password = getParameter("password", req);
         String third = getParameter("thirdParam", req);
         boolean success = false;
         if (isSet("organiser", req)) {
             createOrganiser();
             try {
-                success = getOrganiserFacade().register(new String[]{email, password, third});
-                setPlayer(false);
+                success = getOrganiserFacade().register(new String[]{email, third});
             } catch (IllegalArgumentException e) {
                 if (e.getMessage().equals(OrganiserManagement.EMAIL_IN_USE)) {
                     resp.sendError(409, e.getMessage());
@@ -80,14 +78,11 @@ public class Login extends Servlet {
             }
         } else {
             createPlayer();
-            success = getPlayerFacade().register(new String[]{email, password, third});
-            setPlayer(true);
+            success = getPlayerFacade().register(new String[]{email, third});
         }
         if (success) {
             resp.sendError(HttpServletResponse.SC_OK);
         }
-        updateLanguage();
-
     }
 
     private void login(HttpServletRequest req, HttpServletResponse resp) throws IOException, HttpError {

--- a/src/main/java/com/csselect/inject/Injector.java
+++ b/src/main/java/com/csselect/inject/Injector.java
@@ -30,16 +30,18 @@ public final class Injector {
     public static Injector getInstance() {
         if (injector == null) {
             synchronized (Injector.class) {
-                if (testMode) {
-                    injector = new Injector(new CSSelectTestModule());
-                } else if (mysqlTestMode) {
-                    injector = new Injector(new CSSelectMysqlTestModule(new MockConfiguration()));
-                } else {
-                    try {
-                        injector = new Injector(new CSSelectModule(new ApacheCommonsConfiguration()));
-                    } catch (ConfigurationException | NoClassDefFoundError e) {
-                        injector = null;
-                        throw new ConfigurationException();
+                if (injector == null) {
+                    if (testMode) {
+                        injector = new Injector(new CSSelectTestModule());
+                    } else if (mysqlTestMode) {
+                        injector = new Injector(new CSSelectMysqlTestModule(new MockConfiguration()));
+                    } else {
+                        try {
+                            injector = new Injector(new CSSelectModule(new ApacheCommonsConfiguration()));
+                        } catch (ConfigurationException | NoClassDefFoundError e) {
+                            injector = null;
+                            throw new ConfigurationException();
+                        }
                     }
                 }
             }

--- a/src/main/java/com/csselect/user/management/OrganiserManagement.java
+++ b/src/main/java/com/csselect/user/management/OrganiserManagement.java
@@ -10,10 +10,6 @@ import com.csselect.user.management.safety.Encrypter;
  * Management class for registration and login of {@link Organiser}
  */
 public final class OrganiserManagement extends UserManagement {
-    /**
-     * Error String if Email is in use (registration)
-     */
-    public static final String EMAIL_IN_USE = "Email is already in use";
 
     /**
      * Error string if master password is incorrect (registration)
@@ -30,9 +26,8 @@ public final class OrganiserManagement extends UserManagement {
         assert parameters.length == 3;
         Configuration config = Injector.getInstance().getConfiguration();
         String email = parameters[0];
-        String password = parameters[1];
-        String globalPassword = parameters[2];
-
+        String password = this.createTemporaryPassword();
+        String globalPassword = parameters[1];
         if (!config.getOrganiserPassword().equals(globalPassword)) {
             throw new IllegalArgumentException(MASTER_PASSWORD_INCORRECT);
         }
@@ -43,7 +38,7 @@ public final class OrganiserManagement extends UserManagement {
         if (organiser == null) {
             throw new IllegalArgumentException(EMAIL_IN_USE);
         }
-        organiser.login();
+        sendConfirmationMail(email, password);
         return organiser;
     }
 

--- a/src/main/java/com/csselect/user/management/OrganiserManagement.java
+++ b/src/main/java/com/csselect/user/management/OrganiserManagement.java
@@ -18,17 +18,15 @@ public final class OrganiserManagement extends UserManagement {
 
     /**
      * Register an organiser with 3 parameters email, password and global password
-     * @param parameters Registration parameters
+     * @param email organisers email
+     * @param masterPassword masterPassword used in the frontend
      * @return {@link Organiser} object
      * @throws IllegalArgumentException if email is in use or masterpassword is incorrect
      */
-    public Organiser register(String[] parameters) throws IllegalArgumentException {
-        assert parameters.length == 3;
+    public Organiser register(String email, String masterPassword) throws IllegalArgumentException {
         Configuration config = Injector.getInstance().getConfiguration();
-        String email = parameters[0];
         String password = this.createTemporaryPassword();
-        String globalPassword = parameters[1];
-        if (!config.getOrganiserPassword().equals(globalPassword)) {
+        if (!config.getOrganiserPassword().equals(masterPassword)) {
             throw new IllegalArgumentException(MASTER_PASSWORD_INCORRECT);
         }
         String salt = Encrypter.getRandomSalt();

--- a/src/main/java/com/csselect/user/management/PlayerManagement.java
+++ b/src/main/java/com/csselect/user/management/PlayerManagement.java
@@ -12,14 +12,12 @@ public final class PlayerManagement extends UserManagement {
 
     /**
      * Register a player with parameters email, password and username
-     * @param parameters Registration parameters
+     * @param email players email
+     * @param username players username
      * @return {@link Player} object
      */
-    public Player register(String[] parameters) {
-        assert parameters.length == 3;
-        String email = parameters[0];
+    public Player register(String email, String username) {
         String password = this.createTemporaryPassword();
-        String username = parameters[1];
         String salt = Encrypter.getRandomSalt();
         String encryptedPassword = Encrypter.encrypt(password, salt);
         Player player = Injector.getInstance().getDatabaseAdapter()

--- a/src/main/java/com/csselect/user/management/PlayerManagement.java
+++ b/src/main/java/com/csselect/user/management/PlayerManagement.java
@@ -18,15 +18,16 @@ public final class PlayerManagement extends UserManagement {
     public Player register(String[] parameters) {
         assert parameters.length == 3;
         String email = parameters[0];
-        String password = parameters[1];
-        String username = parameters[2];
+        String password = this.createTemporaryPassword();
+        String username = parameters[1];
         String salt = Encrypter.getRandomSalt();
         String encryptedPassword = Encrypter.encrypt(password, salt);
         Player player = Injector.getInstance().getDatabaseAdapter()
                 .createPlayer(email, encryptedPassword, salt, username);
-        if (player != null) {
-            player.login();
+        if (player == null) {
+            throw new IllegalArgumentException(EMAIL_IN_USE);
         }
+        sendConfirmationMail(email, password);
         return player;
     }
 

--- a/src/main/java/com/csselect/user/management/UserManagement.java
+++ b/src/main/java/com/csselect/user/management/UserManagement.java
@@ -1,5 +1,7 @@
 package com.csselect.user.management;
 
+import com.csselect.email.EmailSender;
+import com.csselect.inject.Injector;
 import com.csselect.user.User;
 import com.csselect.user.management.safety.Encrypter;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -9,10 +11,20 @@ import org.apache.commons.lang3.RandomStringUtils;
  */
 public abstract class UserManagement {
 
+    /**
+     * Error String if Email is in use (registration)
+     */
+    public static final String EMAIL_IN_USE = "Email is already in use";
+
     private static final int MIN_TEMP_PASSWORD_LENGTH = 16;
     private static final int MAX_TEMP_PASSWORD_LENGTH = 20;
     private static final int MIN_SALT_LENGTH = 40;
     private static final int MAX_SALT_LENGTH = 70;
+    private static final String REGISTRATION_CONFIRMATION_HEADER = "CS:Select Registration";
+    private static final String REGISTRATION_CONFIRMATION_MESSAGE = "Welcome to CS:Select, your temporary password is"
+            + " '%s'! Please login with your temporary password under "
+            + Injector.getInstance().getConfiguration().getCSSelectURL()
+            + " and change it to an own, safe one as fast as possible!";
 
     /**
      * Resets the password of the {@link User} with the given email address to a temporary one and sends a mail
@@ -20,11 +32,29 @@ public abstract class UserManagement {
      * @param email email address of the user
      */
     public void resetPassword(String email) {
-        String tempPassword = RandomStringUtils.randomAlphanumeric(MIN_TEMP_PASSWORD_LENGTH, MAX_TEMP_PASSWORD_LENGTH);
+        String tempPassword = this.createTemporaryPassword();
         String salt = RandomStringUtils.randomAlphanumeric(MIN_SALT_LENGTH, MAX_SALT_LENGTH);
         String encryptedPasswort = Encrypter.encrypt(tempPassword, salt);
         User user = getUser(email);
         user.resetPassword(tempPassword, encryptedPasswort, salt);
+    }
+
+    /**
+     * Gets a random temporary password
+     * @return temp password
+     */
+    String createTemporaryPassword() {
+        return RandomStringUtils.randomAlphanumeric(MIN_TEMP_PASSWORD_LENGTH, MAX_TEMP_PASSWORD_LENGTH);
+    }
+
+    /**
+     * Sends a registration mail to the user with the given email and sends his temporary password
+     * @param email email to send to
+     * @param tempPassword password to include
+     */
+    void sendConfirmationMail(String email, String tempPassword) {
+        EmailSender.sendEmail(email, REGISTRATION_CONFIRMATION_HEADER,
+                String.format(REGISTRATION_CONFIRMATION_MESSAGE, tempPassword));
     }
 
     /**

--- a/src/main/resources/locale/Locale.properties
+++ b/src/main/resources/locale/Locale.properties
@@ -231,3 +231,4 @@ databaseWarningText=A result database with this name already exists. \
   Do you still want to proceed with creation?
 featureSetNotSet=Feature-set not set
 noDatabase=No database is accessible in the backend
+checkEmail=You have received an email with a temporary password. It can take a few minutes for you to receive the email. Please change this password as soon as you log in under 'settings'

--- a/src/main/resources/locale/Locale_de.properties
+++ b/src/main/resources/locale/Locale_de.properties
@@ -230,3 +230,4 @@ databaseWarningText=Eine Datenbank mit diesem Namen existiert bereits. \
   Möchten sie mit der Erstellung fortfahren?
 featureSetNotSet=Merkmals-Set nicht angegeben
 noDatabase=Keine Datenbank gefunden. 
+checkEmail=Sie haben eine Email mit einem tempor\u00e4ren Passwort erhalten. Es kann ein paar Minuten dauern bis Sie die Email erhalten. Sie sollten dieses Passwort nach dem Anmelden sofort \u00e4ndern

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -9,6 +9,9 @@
                     <div class="alert alert-danger mt-3" v-bind:class="{ collapse: !(autoLogout() == 'true') }">
                         <fmt:message key="autoLogout"/>
                     </div>
+                    <div class="alert alert-info mt-3" v-bind:class="{ collapse: !(checkEmail == 'true') }">
+                        <fmt:message key="checkEmail"/>
+                    </div>
                     <div class="alert alert-danger mt-3" v-bind:class="{ invisible: alert }">
                         <fmt:message key="noLogin"/>
                     </div>

--- a/src/main/webapp/register.jsp
+++ b/src/main/webapp/register.jsp
@@ -39,18 +39,18 @@
                     </div>
                     <div class="form-group fixed-height login-form-div">
                         <div class="position-absolute login-form-absolute" v-bind:class="{ invisible: organiser !='organiser' }">
-                            <label for="thirdParam"><fmt:message key="masterPassword"/></label>
-                            <input type="password" class="form-control" id="thirdParam"
-                                   placeholder="<fmt:message key="masterPassword"/>" v-model="thirdParam">
+                            <label for="secondParam"><fmt:message key="masterPassword"/></label>
+                            <input type="password" class="form-control" id="secondParam"
+                                   placeholder="<fmt:message key="masterPassword"/>" v-model="secondParam">
                         </div>
                         <div class="position-absolute login-form-absolute" v-bind:class="{ invisible: organiser =='organiser' }">
-                            <label for="thirdParam"><fmt:message key="username"/></label>
-                            <input type="text" class="form-control" id="thirdParam"
-                                   placeholder="<fmt:message key="username"/>" v-model="thirdParam">
+                            <label for="secondParam"><fmt:message key="username"/></label>
+                            <input type="text" class="form-control" id="secondParam"
+                                   placeholder="<fmt:message key="username"/>" v-model="secondParam">
                         </div>
                     </div>
                     <button type="submit" class="btn btn-primary login-form-button" v-on:click="submit"
-                            :disabled="passwordRepeat != password || email == '' || password == '' || thirdParam == ''">
+                            :disabled="passwordRepeat != password || email == '' || password == '' || secondParam == ''">
                         <fmt:message key="register"/></button>
                 </div>
             </form>

--- a/src/main/webapp/register.jsp
+++ b/src/main/webapp/register.jsp
@@ -25,19 +25,6 @@
                         <small id="login" class="form-text text-muted"><a href="index.jsp"><fmt:message
                                 key="loginPrompt"/></a></small>
                     </div>
-                    <div class="form-group login-form-div">
-                        <label for="password"><fmt:message key="password"/></label>
-                        <input type="password" class="form-control" name="password" id="password"
-                               placeholder="<fmt:message key="password"/>" v-model="password">
-                    </div>
-                    <div class="form-group login-form-div">
-                        <label for="passwordRepeat"><fmt:message key="passwordRepeat"/></label>
-                        <input type="password" class="form-control" id="passwordRepeat"
-                               placeholder="<fmt:message key="passwordRepeat"/>" v-model="passwordRepeat">
-                    </div>
-                    <div class="alert alert-danger login-form-div" v-bind:class="{collapse: passwordRepeat == password }">
-                        <fmt:message key="passwordNoMatch"/>
-                    </div>
                     <div class="login-form-div">
                         <div class="form-check" id="organiserCheck">
                             <input type="radio" class="form-check-input" name="organiser" id="player"

--- a/src/main/webapp/src/js/login.js
+++ b/src/main/webapp/src/js/login.js
@@ -43,4 +43,12 @@ var app1 = new Vue({
             localStorage.setItem("autoLogout", false);
             return val;
         }
-    }});
+    },
+    computed: {
+        checkEmail: function() {
+            var val = localStorage.getItem('checkEmail');
+            localStorage.setItem('checkEmail', false);
+            return val;
+        }
+    }
+    });

--- a/src/main/webapp/src/js/register.js
+++ b/src/main/webapp/src/js/register.js
@@ -3,7 +3,7 @@ var app1 = new Vue({
         data: {
             email: '',
             organiser: 'player', // so that the player is the default option for registering
-            thirdParam: '',
+            secondParam: '',
             emailInUse: false,
             missingConfig: false,
             wrongMasterPassword: false,
@@ -11,7 +11,7 @@ var app1 = new Vue({
         },
     watch:{
         organiser: function () {
-            this.thirdParam = '';
+            this.secondParam = '';
         }
     },
         methods: {
@@ -22,7 +22,7 @@ var app1 = new Vue({
                   url: 'login/register',
                   params: {email: this.email,
                             organiser: this.organiser === 'organiser',
-                            thirdParam: this.thirdParam
+                            secondParam: this.secondParam
                             }
                 }).then(function () {
                     localStorage.setItem('checkEmail', true);

--- a/src/main/webapp/src/js/register.js
+++ b/src/main/webapp/src/js/register.js
@@ -25,6 +25,7 @@ var app1 = new Vue({
                             thirdParam: this.thirdParam
                             }
                 }).then(function () {
+                    localStorage.setItem('checkEmail', true);
                     window.open("index.jsp","_self")
                 }).catch(function (error) {
                     if (error.response.status === 550) {

--- a/src/main/webapp/src/js/register.js
+++ b/src/main/webapp/src/js/register.js
@@ -2,8 +2,6 @@ var app1 = new Vue({
     el: '#registerForm',
         data: {
             email: '',
-            password: '',
-            passwordRepeat: '',
             organiser: 'player', // so that the player is the default option for registering
             thirdParam: '',
             emailInUse: false,
@@ -23,27 +21,19 @@ var app1 = new Vue({
                   method: 'post',
                   url: 'login/register',
                   params: {email: this.email,
-                            password: this.password,
-                            organiser: this.organiser == 'organiser',
+                            organiser: this.organiser === 'organiser',
                             thirdParam: this.thirdParam
                             }
-                }).then(function (response) {
-                    if (app1.organiser == "player") {
-                        window.location.href = "player.jsp"
-                    }
-                    else if (app1.organiser == "organiser") {
-                        window.location.href = "organiser.jsp"
-                    }
-                    // if (response.status == 202) window.open("login.jsp","_self")
-
+                }).then(function () {
+                    window.open("index.jsp","_self")
                 }).catch(function (error) {
-                    if (error.response.status == 550) {
+                    if (error.response.status === 550) {
                         app1.missingConfig = true;
-                    } else if(error.response.status == 552) {
+                    } else if(error.response.status === 552) {
                         app1.missingDatabase = true;
-                    } else if (error.response.status == 409) {
+                    } else if (error.response.status === 409) {
                         app1.emailInUse = true;
-                    } else if (error.response.status == 401) {
+                    } else if (error.response.status === 401) {
                         app1.wrongMasterPassword = true;
                     }
                 })

--- a/src/test/java/com/csselect/user/OrganiserTests.java
+++ b/src/test/java/com/csselect/user/OrganiserTests.java
@@ -11,17 +11,16 @@ import org.junit.Test;
 import java.util.Collection;
 
 public class OrganiserTests extends TestClass {
+
+
+    private static final String EMAIL = "skywalker1@csselect.com";
+
     private Organiser organiser;
 
     @Override
     public void setUp() {
-        String globalPassword = Injector.getInstance().getConfiguration().getOrganiserPassword();
         OrganiserManagement om = new OrganiserManagement();
-        String[] args = new String[3];
-        args[0] = "voldi@csselect.com";
-        args[1] = "#ElDeRsTaB!#";
-        args[2] = globalPassword;
-        organiser = om.register(args);
+        organiser = om.register(EMAIL, Injector.getInstance().getConfiguration().getOrganiserPassword());
     }
 
     @Override

--- a/src/test/java/com/csselect/user/UserManagementTests.java
+++ b/src/test/java/com/csselect/user/UserManagementTests.java
@@ -14,13 +14,17 @@ public class UserManagementTests extends TestClass {
     private OrganiserManagement om;
     private Organiser harry;
     private Organiser voldemort;
-    private String globalPassword;
+    private String GLOBAL_PASSWORD;
+    private static final String EMAIL_1 = "skywalker1@csselect.com";
+    private static final String USERNAME_1 = "Luke1";
+    private static final String EMAIL_2 = "vader1@csselect.com";
+    private static final String USERNAME_2 = "Darth1";
 
     @Override
     public void setUp() {
+        GLOBAL_PASSWORD = Injector.getInstance().getConfiguration().getOrganiserPassword();
         pm = new PlayerManagement();
         om = new OrganiserManagement();
-        globalPassword = Injector.getInstance().getConfiguration().getOrganiserPassword();
     }
 
     @Override
@@ -29,99 +33,45 @@ public class UserManagementTests extends TestClass {
         luke = null;
         harry = null;
         voldemort = null;
+        om = null;
+        pm = null;
     }
 
     @Test
     public void testValidRegistrationPlayer() {
-        String[] args = new String[3];
-        args[0] = "skywalker1@csselect.com";
-        args[1] = "Nein!11!!1";
-        args[2] = "Luke1";
-
-        luke = pm.register(args);
+        luke = pm.register(EMAIL_1, USERNAME_1);
         Assert.assertNotNull(luke);
-
-        Assert.assertTrue(luke.isLoggedIn());
         Assert.assertTrue(luke.getGames().isEmpty());
         Assert.assertNotNull(luke.getStats());
         Assert.assertNull(luke.getActiveRound());
         Assert.assertTrue(luke.getRounds().isEmpty());
-
-        testLoginExistingPlayer();
-        testIllegalLoginAsOrganiser();
-        testLoginPlayerAfterChangingEmail();
     }
 
     @Test
     public void testTwoValidRegistrationsPlayer() {
-        String[] args1 = new String[3];
-        args1[0] = "vader1@csselect.com";
-        args1[1] = "IchBinDeinVater1968";
-        args1[2] = "Darth1";
-
-        String[] args2 = new String[3];
-        args2[0] = "skywalker2@csselect.com";
-        args2[1] = "Nein!11!!1";
-        args2[2] = "Luke2";
-
-        darth = pm.register(args1);
+        darth = pm.register(EMAIL_1, USERNAME_1);
         Assert.assertNotNull(darth);
-        luke = pm.register(args2);
+        luke = pm.register(EMAIL_2, USERNAME_2);
         Assert.assertNotNull(luke);
         Assert.assertNotSame(darth, luke);
-
-        testLoginPlayerAfterChangingPassword();
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testDuplicateEmailRegistrationPlayer() {
-        String[] args1 = new String[3];
-        args1[0] = "vader2@csselect.com";
-        args1[1] = "IchBinDeinVater1968";
-        args1[2] = "Darth2";
-
-        String[] args2 = new String[3];
-        args2[0] = "vader2@csselect.com";
-        args2[1] = "Nein!11!!1";
-        args2[2] = "Luke3";
-
-        darth = pm.register(args1);
-        luke = pm.register(args2);
-
-        Assert.assertNotNull(darth);
-        Assert.assertNull(luke);
+        darth = pm.register(EMAIL_1, USERNAME_1);
+        luke = pm.register(EMAIL_1, USERNAME_2);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testDuplicateUsernameRegistrationPlayer() {
-        String[] args1 = new String[3];
-        args1[0] = "vader3@csselect.com";
-        args1[1] = "IchBinDeinVater1968";
-        args1[2] = "Darth3";
-
-        String[] args2 = new String[3];
-        args2[0] = "luke3@csselect.com";
-        args2[1] = "Nein!11!!1";
-        args2[2] = "Darth3";
-
-        darth = pm.register(args1);
-        luke = pm.register(args2);
-
-        Assert.assertNotNull(darth);
-        Assert.assertNull(luke);
+        darth = pm.register(EMAIL_1, USERNAME_1);
+        luke = pm.register(EMAIL_2, USERNAME_1);
     }
 
     @Test
     public void testValidRegistrationOrganiser() {
-        String[] args = new String[3];
-        args[0] = "voldi1@csselect.com";
-        args[1] = "#ElDeRsTaB!#";
-        args[2] = globalPassword;
-
-        voldemort = om.register(args);
+        voldemort = om.register(EMAIL_1, GLOBAL_PASSWORD);
         Assert.assertNotNull(voldemort);
-
-        Assert.assertTrue(voldemort.isLoggedIn());
         Assert.assertNotNull(voldemort.getActiveGames());
         Assert.assertTrue(voldemort.getActiveGames().isEmpty());
         Assert.assertNotNull(voldemort.getTerminatedGames());
@@ -132,118 +82,22 @@ public class UserManagementTests extends TestClass {
 
     @Test
     public void testTwoValidRegistrationsOrganiser() {
-        String[] args1 = new String[3];
-        args1[0] = "voldi2@csselect.com";
-        args1[1] = "#ElDeRsTaB!#";
-        args1[2] = globalPassword;
-
-        String[] args2 = new String[3];
-        args2[0] = "harry1@csselect.com";
-        args2[1] = "#FiniteIncantatem!#";
-        args2[2] = globalPassword;
-
-        voldemort = om.register(args1);
+        voldemort = om.register(EMAIL_1, GLOBAL_PASSWORD);
         Assert.assertNotNull(voldemort);
-        harry = om.register(args2);
+        harry = om.register(EMAIL_2, GLOBAL_PASSWORD);
         Assert.assertNotNull(harry);
         Assert.assertNotSame(harry, voldemort);
-
-        testLoginExistingOrganiser();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testDuplicateEmailRegistrationOrganiser() {
-        String[] args1 = new String[3];
-        args1[0] = "voldi3@csselect.com";
-        args1[1] = "#ElDeRsTaB!#";
-        args1[2] = globalPassword;
-
-        String[] args2 = new String[3];
-        args2[0] = "voldi3@csselect.com";
-        args2[1] = "#FiniteIncantatem!#";
-        args2[2] = globalPassword;
-
-        voldemort = om.register(args1);
+        voldemort = om.register(EMAIL_1, GLOBAL_PASSWORD);
         Assert.assertNotNull(voldemort);
-        harry = om.register(args2);
+        harry = om.register(EMAIL_1, GLOBAL_PASSWORD);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIllegalOrganiserPasswordRegistration() {
-        String[] args = new String[3];
-        args[0] = "voldi4@csselect.com";
-        args[1] = "#ElDeRsTaB!#";
-        args[2] = "";
-
-        voldemort = om.register(args);
-    }
-
-    private void testLoginExistingPlayer() {
-        luke = pm.login("skywalker1@csselect.com", "Nein!11!!1");
-        Assert.assertNotNull(luke);
-        Assert.assertTrue(luke.isLoggedIn());
-    }
-
-    private void testLoginPlayerAfterChangingEmail() {
-        luke = pm.login("skywalker1@csselect.com", "Nein!11!!1");
-        Assert.assertNotNull(luke);
-        luke.changeEmail("skywalker@csselect.com");
-        luke = pm.login("skywalker1@csselect.com", "Nein!11!!1");
-        Assert.assertNull(luke);
-        luke = pm.login("skywalker@csselect.com", "Nein!11!!1");
-        Assert.assertNotNull(luke);
-        luke.changeEmail("skywalker1@csselect.com");
-    }
-
-    private void testLoginPlayerAfterChangingPassword() {
-        darth = pm.login("vader1@csselect.com", "IchBinDeinVater1968");
-        Assert.assertNotNull(darth);
-        darth.changePassword("IchBinEchtDeinVater1968");
-        darth = pm.login("vader1@csselect.com", "IchBinDeinVater1968");
-        Assert.assertNull(darth);
-        darth = pm.login("vader1@csselect.com", "IchBinEchtDeinVater1968");
-        Assert.assertNotNull(darth);
-        darth.changePassword("IchBinDeinVater1968");
-    }
-
-    private void testLoginExistingOrganiser() {
-        harry = om.login("harry1@csselect.com", "#FiniteIncantatem!#");
-        Assert.assertNotNull(harry);
-        Assert.assertTrue(harry.isLoggedIn());
-
-        testIllegalLoginAsPlayer();
-        testLoginOrganiserAfterChangingEmail();
-        testLoginOrganiserAfterChangingPassword();
-    }
-
-    private void testLoginOrganiserAfterChangingEmail() {
-        harry = om.login("harry1@csselect.com", "#FiniteIncantatem!#");
-        Assert.assertNotNull(harry);
-        harry.changeEmail("harry@csselect.com");
-        harry = om.login("harry1@csselect.com", "#FiniteIncantatem!#");
-        Assert.assertNull(harry);
-        harry = om.login("harry@csselect.com", "#FiniteIncantatem!#");
-        Assert.assertNotNull(harry);
-        harry.changeEmail("harry1@csselect.com");
-    }
-
-    private void testLoginOrganiserAfterChangingPassword() {
-        harry = om.login("harry1@csselect.com", "#FiniteIncantatem!#");
-        Assert.assertNotNull(harry);
-        harry.changePassword("#LumosMaxima!#");
-        harry = om.login("harry1@csselect.com", "#FiniteIncantatem!#");
-        Assert.assertNull(harry);
-        harry = om.login("harry1@csselect.com", "#LumosMaxima!#");
-        Assert.assertNotNull(harry);
-        harry.changePassword("#FiniteIncantatem!#");
-    }
-
-    private void testIllegalLoginAsOrganiser() {
-        harry = om.login("skywalker1@csselect.com", "Nein!11!!1");
-        Assert.assertNull(harry);
-    }
-
-    private void testIllegalLoginAsPlayer() {
-        darth = pm.login("harry1@csselect.com", "#FiniteIncantatem!#");
+        voldemort = om.register(EMAIL_1, "");
     }
 }


### PR DESCRIPTION
We send a confirmation mail with the temporary password after registering, to ensure users have control of their email address
Todo:

- [x] Use temp passwords and send confirmation mails on registration
- [x]  Show an alert/information banner to the user when he is redirected to the login page to notify him to check his email account for our mail

close #216 